### PR TITLE
Add a run-time variable to re-reference observation-based GMSL

### DIFF
--- a/pkg/SLR_CORR_PARAM.h
+++ b/pkg/SLR_CORR_PARAM.h
@@ -35,6 +35,9 @@ C     This is the time interval over which the running average is computed
 C     This is the precip adjustment, updated at each time step
       _RL slrc_precip_adjustment
 
+C     This is the reference to be added to obs to account for bias btw obs and md 
+      _RL slrc_obs_ref
+
 C     These are some i/o parameters
       INTEGER slrc_filePrec
 
@@ -59,6 +62,7 @@ C------------------------------------------------------------------------------|
      & slrc_obs_period,
      & slrc_balancePeriod,
      & slrc_obs_start_time,
-     & slrc_precip_adjustment
+     & slrc_precip_adjustment,
+     & slrc_obs_ref
 
 #endif /* ALLOW_SLR_CORR */

--- a/pkg/slr_corr_adjust_precip.F
+++ b/pkg/slr_corr_adjust_precip.F
@@ -111,6 +111,7 @@ C     This is the target EtaN to adjust the precip toward
      &       /  (slrc_obs_period)
       mean_EtaN_target = (1-alpha) * slrc_obs_timeseries(count0) 
      &                   + alpha * slrc_obs_timeseries(count1)
+     &                  + slrc_obs_ref
 
 C      PRINT *, 'slrc_obs_timeseries',slrc_obs_timeseries
 C      PRINT *, 'myTime', myTime

--- a/pkg/slr_corr_readparms.F
+++ b/pkg/slr_corr_readparms.F
@@ -49,7 +49,8 @@ C----&------------------------------------------------------------------xxxxxxx|
      &     slrc_obs_startdate_1,
      &     slrc_obs_startdate_2,
      &     slrc_obs_period,
-     &     slrc_balancePeriod
+     &     slrc_balancePeriod, 
+     &     slrc_obs_ref
     
       if (debug .eq. 1) then
         WRITE(msgBuf,'(A)') "========================================="
@@ -80,6 +81,7 @@ C----&------------------------------------------------------------------xxxxxxx|
       slrc_obs_period = 0.
       slrc_balancePeriod = 0.
       slrc_obs_start_time = 0.
+      slrc_obs_ref = 0.
 
 C----&------------------------------------------------------------------xxxxxxx|
 C     Write out status to main output and fill in the parameters
@@ -138,6 +140,8 @@ C     Close the open data file
      &                     SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A,F10.3)') "  slrc_obs_start_time: ",
      &                       slrc_obs_start_time
+      WRITE(msgBuf,'(A,E10.3)') "  slrc_obs_ref: ",
+     &                       slrc_obs_ref
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                     SQUEEZE_RIGHT, myThid )
       endif


### PR DESCRIPTION
Add a run-time variable, slrc_obs_ref, to re-reference observation-based GMSL. Oftentimes, the model GMSL and observation-based GMSL are referenced differently, and therefore there is a bias between them. Letting the model correct the bias results in a spin-up issue. The added run-time variable slrc_obs_ref allows the model to ignore the bias but correct the variable part. This is done by choosing a suitable slrc_obs_ref (default is zero) to have the same model and observation-based GMSL at the beginning of the model integration. 