### PR TITLE
Add a CPP option to adjust precipitation only when it is raining

### DIFF
--- a/pkg/slr_corr_adjust_precip.F
+++ b/pkg/slr_corr_adjust_precip.F
@@ -298,7 +298,7 @@ C     & - precip_volume_flux + evap_volume_flux
       endif
 
 C     Convert precip adjustment to a mean per area cell
-C     Total area (denominator) is wet_area by default and corr_area if 
+C     Total area (denominator) is wet_area by default and corr_area if
 C     MODIDY_POSITIVE_PRECIP_ONLY is defined in EXF_OPTIONS.h
 #ifdef MODIDY_POSITIVE_PRECIP_ONLY
       precip_adjustment = precip_adjustment/corr_area


### PR DESCRIPTION
If the CPP option MODIDY_POSITIVE_PRECIP_ONLY is defined in EXF_OPTIONS.h, precipitation will only be adjusted at places where it is positive (i.e., it is raining).