### PR TITLE
Applying a scaling factor to adjust precipitation as the default

### DIFF
--- a/pkg/SLR_CORR_OPTIONS.h
+++ b/pkg/SLR_CORR_OPTIONS.h
@@ -15,9 +15,9 @@ CC When adjusting GMSL, only adjust precipitation
 CC where precipitation is positive
 C#define MODIDY_POSITIVE_PRECIP_ONLY
  
-CC Instead of using a spatially-invariant precipitation
-CC adjustment, apply a scaling factor to precipitation
-C#define SCALE_PRECIP_TO_ADJUST
+C Instead of using a spatially-invariant precipitation
+C adjustment, apply a scaling factor to precipitation
+#define SCALE_PRECIP_TO_ADJUST
 
 #endif /* ALLOW_SLR_CORR */
 #endif /* ALLOW_SLR_OPTIONS_H */


### PR DESCRIPTION
Change the default way to adjust precipitation to match model GMSL with observation

The new default way is to apply a spatially-invariant scaling factor to precipitations so the adjustments are proportional to precipitations. The old default way was to add or subtract a spatially-invariant adjustment from precipitations. 